### PR TITLE
(MODULES-7051) remove default node from credentials configuration

### DIFF
--- a/manifests/conf/device.pp
+++ b/manifests/conf/device.pp
@@ -30,7 +30,7 @@ define device_manager::conf::device (
         hocon_setting { "${name}_${key}":
           ensure  => present,
           path    => $credentials_file,
-          setting => "default.node.${key}",
+          setting => $key,
           value   => $value,
         }
       }

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -269,35 +269,35 @@ describe 'device_manager' do
     it {
       is_expected.to contain_hocon_setting("#{title}_address").with(
         'path'    => device_yaml_file,
-        'setting' => 'default.node.address',
+        'setting' => 'address',
         'value'   => '10.0.0.245',
       )
     }
     it {
       is_expected.to contain_hocon_setting("#{title}_port").with(
         'path'    => device_yaml_file,
-        'setting' => 'default.node.port',
+        'setting' => 'port',
         'value'   => '22',
       )
     }
     it {
       is_expected.to contain_hocon_setting("#{title}_username").with(
         'path'    => device_yaml_file,
-        'setting' => 'default.node.username',
+        'setting' => 'username',
         'value'   => 'admin',
       )
     }
     it {
       is_expected.to contain_hocon_setting("#{title}_password").with(
         'path'    => device_yaml_file,
-        'setting' => 'default.node.password',
+        'setting' => 'password',
         'value'   => 'cisco',
       )
     }
     it {
       is_expected.to contain_hocon_setting("#{title}_enable_password").with(
         'path'    => device_yaml_file,
-        'setting' => 'default.node.enable_password',
+        'setting' => 'enable_password',
         'value'   => 'cisco',
       )
     }


### PR DESCRIPTION
This commit matches the same change in the cisco_ios module:
https://github.com/puppetlabs/cisco_ios/pull/176
Also referenced in MODULES-7099.

Note: This module uses the hocon_setting resource, which manages each setting.
It may be better to convert the hash to HOCON and use a File resource.