### PR TITLE
(MODULES-7101) rename scheduled task

### DIFF
--- a/manifests/run/via_scheduled_task/device.pp
+++ b/manifests/run/via_scheduled_task/device.pp
@@ -18,8 +18,9 @@ define device_manager::run::via_scheduled_task::device (
 
     $random_minute = sprintf('%02d', fqdn_rand(59, $name))
     $start_time = "00:${$random_minute}"
+    $task_name = regsubst($name, '\.', '_', 'G')
 
-    scheduled_task { "run puppet device target ${name}":
+    scheduled_task { "run puppet device target ${task_name}":
       ensure    => $scheduled_task_ensure,
       command   => $device_manager::run::command,
       arguments => "${device_manager::run::arguments} --target=${name}",

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -145,6 +145,7 @@ describe 'device_manager' do
 
   context 'declared on Windows, running Puppet 5.0, with run_interval' do
     let(:title)  { 'f5.example.com' }
+    let(:task_name) { 'f5_example_com' }
     let(:params) do
       {
         ensure: :present,
@@ -170,7 +171,7 @@ describe 'device_manager' do
     it { is_expected.to contain_class('F5') }
     it { is_expected.to contain_device_manager__run__via_scheduled_task__device(title) }
     it {
-      is_expected.to contain_scheduled_task("run puppet device target #{title}").with(
+      is_expected.to contain_scheduled_task("run puppet device target #{task_name}").with(
         'command' => 'C:\\Program Files\\Puppet Labs\\Puppet\\bin\\puppet',
       )
     }

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -9,7 +9,7 @@ describe 'device_manager' do
   end
 
   context 'declared on a device' do
-    let(:title)  { 'cisco.example.com' }
+    let(:title) { 'cisco.example.com' }
     let(:params) do
       {
         ensure: :present,
@@ -26,7 +26,7 @@ describe 'device_manager' do
   end
 
   context 'declared on Linux, running Puppet 5.0, with values for all device.conf parameters' do
-    let(:title)  { 'f5.example.com' }
+    let(:title) { 'f5.example.com' }
     let(:params) do
       {
         ensure: :present,
@@ -52,7 +52,7 @@ describe 'device_manager' do
   end
 
   context 'declared on Windows, running Puppet 5.0, with values for all device.conf parameters' do
-    let(:title)  { 'f5.example.com' }
+    let(:title) { 'f5.example.com' }
     let(:params) do
       {
         ensure: :present,
@@ -79,7 +79,7 @@ describe 'device_manager' do
   end
 
   context 'declared on Linux, running Puppet 4.10, with run_interval' do
-    let(:title)  { 'f5.example.com' }
+    let(:title) { 'f5.example.com' }
     let(:params) do
       {
         ensure: :present,
@@ -111,7 +111,7 @@ describe 'device_manager' do
   end
 
   context 'declared on Linux, running Puppet 5.0, with run_interval' do
-    let(:title)  { 'f5.example.com' }
+    let(:title) { 'f5.example.com' }
     let(:params) do
       {
         ensure: :present,
@@ -144,7 +144,7 @@ describe 'device_manager' do
   end
 
   context 'declared on Windows, running Puppet 5.0, with run_interval' do
-    let(:title)  { 'f5.example.com' }
+    let(:title) { 'f5.example.com' }
     let(:task_name) { 'f5_example_com' }
     let(:params) do
       {
@@ -180,7 +180,7 @@ describe 'device_manager' do
   # The puppet command is quoted in this Exec to support spaces in the path on Windows.
 
   context 'declared on Linux, running Puppet 5.0, with run_via_exec' do
-    let(:title)  { 'f5.example.com' }
+    let(:title) { 'f5.example.com' }
     let(:params) do
       {
         ensure: 'present',
@@ -213,7 +213,7 @@ describe 'device_manager' do
   end
 
   context 'declared on Linux, running Puppet 5.0, with run_interval and run_via_exec parameters' do
-    let(:title)  { 'f5.example.com' }
+    let(:title) { 'f5.example.com' }
     let(:params) do
       {
         ensure: :present,
@@ -237,7 +237,7 @@ describe 'device_manager' do
   end
 
   context 'declared on Linux, running Puppet 5.5, with credentials' do
-    let(:title)  { 'cisco.example.com' }
+    let(:title) { 'cisco.example.com' }
     let(:params) do
       {
         ensure: :present,
@@ -305,7 +305,7 @@ describe 'device_manager' do
   end
 
   context 'declared on Linux, running Puppet 5.5, with credentials and url parameters' do
-    let(:title)  { 'cisco.example.com' }
+    let(:title) { 'cisco.example.com' }
     let(:params) do
       {
         ensure: :present,


### PR DESCRIPTION
Workaround for MODULES-7130: Cannot configure a scheduled task with two "." in the name.
    
With this commit, periods are replaced with underscores.