### PR TITLE
(MODULES-7051) use to_json instead of hocon_setting

### DIFF
--- a/manifests/conf/device.pp
+++ b/manifests/conf/device.pp
@@ -23,16 +23,10 @@ define device_manager::conf::device (
       $url_url = $url
     } else {
       $url_url = "file://${credentials_file}"
+      $credentials_json = to_json_pretty($credentials)
       file { $credentials_file:
-        ensure => file,
-      }
-      $credentials.each |$key, $value| {
-        hocon_setting { "${name}_${key}":
-          ensure  => present,
-          path    => $credentials_file,
-          setting => $key,
-          value   => $value,
-        }
+        ensure  => file,
+        content => $credentials_json,
       }
     }
 

--- a/manifests/conf/device.pp
+++ b/manifests/conf/device.pp
@@ -20,21 +20,23 @@ define device_manager::conf::device (
     # or define the credentials in a HOCON file and set the url to that file.
 
     if (empty($credentials)) {
-      $url_url = $url
+      $url_value = $url
     } else {
-      $url_url = "file://${credentials_file}"
+      $url_value = "file://${credentials_file}"
       $credentials_json = to_json_pretty($credentials)
+
       file { $credentials_file:
         ensure  => file,
         content => $credentials_json,
       }
+
     }
 
-    $debug_transport = $debug ? { true => "debug\n", default => '' }
+    $debug_value = $debug ? { true => "debug\n", default => '' }
 
     concat::fragment{ "device_conf ${name}":
       target  => $device_manager::conf::device_conf_file,
-      content => "[${name}]\ntype ${type}\nurl ${url_url}\n${debug_transport}\n",
+      content => "[${name}]\ntype ${type}\nurl ${url_value}\n${debug_value}\n",
       order   => '99',
       tag     => "device_${name}",
     }

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -266,42 +266,6 @@ describe 'device_manager' do
     # it {
     #   is_expected.to contain_concat_fragment("device_manager_conf [#{title}]").with('content').including("url file://#{device_yaml_file}")
     # }
-
-    it {
-      is_expected.to contain_hocon_setting("#{title}_address").with(
-        'path'    => device_yaml_file,
-        'setting' => 'address',
-        'value'   => '10.0.0.245',
-      )
-    }
-    it {
-      is_expected.to contain_hocon_setting("#{title}_port").with(
-        'path'    => device_yaml_file,
-        'setting' => 'port',
-        'value'   => '22',
-      )
-    }
-    it {
-      is_expected.to contain_hocon_setting("#{title}_username").with(
-        'path'    => device_yaml_file,
-        'setting' => 'username',
-        'value'   => 'admin',
-      )
-    }
-    it {
-      is_expected.to contain_hocon_setting("#{title}_password").with(
-        'path'    => device_yaml_file,
-        'setting' => 'password',
-        'value'   => 'cisco',
-      )
-    }
-    it {
-      is_expected.to contain_hocon_setting("#{title}_enable_password").with(
-        'path'    => device_yaml_file,
-        'setting' => 'enable_password',
-        'value'   => 'cisco',
-      )
-    }
   end
 
   context 'declared on Linux, running Puppet 5.5, with credentials and url parameters' do


### PR DESCRIPTION
This is a potential improvement, for review ...

Prior to this commit:

hocon_setting requires one resource per setting:

File[/etc/puppetlabs/puppet/devices/cisco.example.com.yaml]/ensure
Hocon_setting[cisco.example.com_address]/ensure
Hocon_setting[cisco.example.com_port]/ensure
Hocon_setting[cisco.example.com_username]/ensure
Hocon_setting[cisco.example.com_password]/ensure
Hocon_setting[cisco.example.com_enable_password]/ensure

With this commit, use the existing File resource for all settings:

File[/etc/puppetlabs/puppet/devices/cisco.example.com.yaml]/ensure

This should be faster, and less noisy in regard to events/reports.
This also prevents individual settings from being orphaned.