### PR TITLE
(FM-7069) HOCON vs YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ This will output that the certificate for the device has been signed:
 ```bash
 Signing Certificate Request for:
   "bigip.example.com" (SHA256) ...
-Notice: Signed certificate request for cisco.example.com
+Notice: Signed certificate request for bigip.example.com
 Notice: Removing file Puppet::SSL::CertificateRequest bigip.example.com at '/etc/puppetlabs/puppet/ssl/ca/requests/bigip.example.com.pem'
 ```
 

--- a/manifests/conf/device.pp
+++ b/manifests/conf/device.pp
@@ -12,7 +12,7 @@ define device_manager::conf::device (
 
   include device_manager::conf
 
-  $credentials_file = "${device_manager::conf::devices_directory}/${name}.yaml"
+  $credentials_file = "${device_manager::conf::devices_directory}/${name}.conf"
 
   if ($ensure == 'present') {
 

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -254,7 +254,7 @@ describe 'device_manager' do
         os: { family: 'redhat' },
       }
     end
-    let(:device_yaml_file) { "/etc/puppetlabs/puppet/devices/#{title}.yaml" }
+    let(:device_credentials_file) { "/etc/puppetlabs/puppet/devices/#{title}.conf" }
 
     it { is_expected.to contain_device_manager(title) }
     it { is_expected.to contain_class('device_manager::conf') }
@@ -264,7 +264,7 @@ describe 'device_manager' do
     # TODO: Identify the rspec syntax for matching an attribute value containing newlines.
     # Or, Identify the rspec syntax for substring matching an attribute value.
     # it {
-    #   is_expected.to contain_concat_fragment("device_manager_conf [#{title}]").with('content').including("url file://#{device_yaml_file}")
+    #   is_expected.to contain_concat_fragment("device_manager_conf [#{title}]").with('content').including("url file://#{device_credentials_file}")
     # }
   end
 


### PR DESCRIPTION
Match changes reflected in FM-7069 ...

The cisco_ios module README documents creating a .yaml credentials file, 
while its code calls Hocon.load(syntax: Hocon::ConfigSyntax::HOCON).

With this commit:

Use .conf as the extension when creating a credentials file.
Remove 'yaml' from the credentials file variable name in the associated spec test.
Sidecar: fix minor discrepancy with certname ('bigip' vs ''cisco') in the README.
