### PR TITLE
(WIP) Add ability to specify default values when using hiera

### DIFF
--- a/functions/merge_default.pp
+++ b/functions/merge_default.pp
@@ -1,0 +1,3 @@
+function device_manager::merge_default($name, $parameters, $defaults) {
+  if $parameters[$name] { deep_merge($defaults[$name], $parameters[$name]) } else { $defaults[$name] }
+}

--- a/functions/value_or_default.pp
+++ b/functions/value_or_default.pp
@@ -1,0 +1,3 @@
+function device_manager::value_or_default($name, $parameters, $defaults) {
+  if $parameters[$name] { $parameters[$name] } else { $defaults[$name] }
+}

--- a/manifests/devices.pp
+++ b/manifests/devices.pp
@@ -47,6 +47,7 @@ class device_manager::devices(Hash $devices = {}) {
 
   if ( (versioncmp($::clientversion, '4.9.0') >= 0) and (! defined('$::serverversion') or versioncmp($::serverversion, '4.9.0') >= 0) ) {
     $hiera_devices = lookup('device_manager::devices', Hash, 'hash', {})
+    $hiera_defaults = lookup('device_manager::defaults', Hash, 'hash', {})
   } else {
     $hiera_devices = hiera_hash('device_manager::devices', {})
   }
@@ -54,13 +55,13 @@ class device_manager::devices(Hash $devices = {}) {
   ($hiera_devices + $devices).each |$title, $device| {
     device_manager {$title:
       name           => $device['name'],
-      type           => $device['type'],
+      type           => device_manager::value_or_default('type', $device, $hiera_defaults),
       url            => $device['url'],
-      credentials    => $device['credentials'],
-      debug          => $device['debug'],
-      run_interval   => $device['run_interval'],
-      run_via_exec   => $device['run_via_exec'],
-      include_module => $device['include_module'],
+      credentials    => device_manager::merge_default('credentials', $device, $hiera_defaults),
+      debug          => device_manager::value_or_default('debug', $device, $hiera_defaults),
+      run_interval   => device_manager::value_or_default('run_interval', $device, $hiera_defaults),
+      run_via_exec   => device_manager::value_or_default('run_via_exec', $device, $hiera_defaults),
+      include_module => device_manager::value_or_default('include_module', $device, $hiera_defaults),
     }
   }
 


### PR DESCRIPTION
This is the beginning of adding default values for hiera based management of nodes.

```yaml
device_manager::defaults:
  type: cisco_ios
  credentials:
    username: admin
    password: s3cr3t
    enable_password: super_s3cr3t

device_manager::devices:
  cat-1:
    credentials:
      address: 192.168.198.60
```

This is particularly interesting for folks managing a large number of entries, as things usernames and passwords may be the same across the fleet.

There's still work to be done in both validating the design and the code itself, but wanted to get this out for discussion.