### PR TITLE
(FM-7383) allow device manager to work with Puppet 6

### DIFF
--- a/spec/acceptance/nodesets/vmpooler.yml
+++ b/spec/acceptance/nodesets/vmpooler.yml
@@ -1,7 +1,7 @@
 ---
 HOSTS:
   masterblaster:
-    pe_dir: http://neptune.puppetlabs.lan/2017.3/ci-ready
+    pe_dir:
     pe_ver:
     pe_upgrade_dir:
     pe_upgrade_ver:

--- a/tasks/run_puppet_device.rb
+++ b/tasks/run_puppet_device.rb
@@ -42,8 +42,7 @@ def read_device_certificate_fingerprints(cert_name)
   return nil unless certificate
   fingerprints = {}
   fingerprints['default'] = certificate.fingerprint
-  ssl_host = Puppet::SSL::Host.new
-  mdas = ssl_host.suitable_message_digest_algorithms
+  mdas = [:SHA1, :SHA224, :SHA256, :SHA384, :SHA512] # ssl_host.suitable_message_digest_algorithms was removed in Puppet 6, specifying the array directly
   mdas.each do |mda|
     fingerprints[mda.to_s] = certificate.fingerprint(mda)
   end


### PR DESCRIPTION
Puppet 6.0.0 removed `puppet cert` and it is now part of `puppetserver ca`. This PR changes the behaviour to use `puppetserver ca sign/list` when running on Puppet 6.0.0 and above.

ssl_host suitable algorithms array was also removed, so referencing the array directly to overcome this behaviour as no mention in Puppet 6.0.0 as to where it was moved too.