### PR TITLE
(FM-7405) clean up run_puppet_device task of supported algorithms

### DIFF
--- a/tasks/run_puppet_device.rb
+++ b/tasks/run_puppet_device.rb
@@ -42,7 +42,11 @@ def read_device_certificate_fingerprints(cert_name)
   return nil unless certificate
   fingerprints = {}
   fingerprints['default'] = certificate.fingerprint
-  mdas = [:SHA1, :SHA224, :SHA256, :SHA384, :SHA512] # ssl_host.suitable_message_digest_algorithms was removed in Puppet 6, specifying the array directly
+  mdas = if Puppet.respond_to? :valid_digest_algorithms
+           Puppet.valid_digest_algorithms
+         else
+           Puppet::SSL::Host.new.suitable_message_digest_algorithms
+         end
   mdas.each do |mda|
     fingerprints[mda.to_s] = certificate.fingerprint(mda)
   end


### PR DESCRIPTION
Puppet 6.0.0 introduced FIPS-aware hashing algorithm support, which intoduced a `Puppet.valid_digest_algorithims` function, previously it was a referenced array so the task has been updated to make use of the new Puppet 6.0.0 FIPS-aware valid algorithms and continue using the referenced array on lower versions.

Tested locally on PE#2018.1 and PE#2019.0