### PR TITLE
CVE-2018-11748 (FM-7258) Update device config file permissions

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -8,7 +8,7 @@ class device_manager::conf {
     File {
       owner => 'root',
       group => 'root',
-      mode  => '0644',
+      mode  => '0640',
     }
   }
 
@@ -29,6 +29,9 @@ class device_manager::conf {
   concat { $device_conf_file:
     backup    => false,
     show_diff => false,
+    owner     => 'root',
+    group     => 'root',
+    mode      => '0640',
   }
 
   concat::fragment{ 'device_conf_comment':

--- a/manifests/conf/device.pp
+++ b/manifests/conf/device.pp
@@ -27,6 +27,9 @@ define device_manager::conf::device (
 
       file { $credentials_file:
         ensure  => file,
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0640',
         content => $credentials_json,
       }
 


### PR DESCRIPTION
This commit removes world readable attribute from device configuration files