### PR TITLE
Tighter version bounding on puppetlabs/hocon

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/hocon",
-      "version_requirement": ">= 1.0.0 < 5.0.0"
+      "version_requirement": ">= 1.0.0 < 2.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
puppetlabs/hocon has only reached v1.0.1 so far. It seems like the requirement should be bound to the latest major version, lest a backwards incompatible change in 2.0.0 or later cause failures.