### PR TITLE
(maint) removing the aio_agent_version fact check

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,6 @@
 # AKA: device_manager::device
 #
-# Configure a single device.
+# Configure a single device on a proxy.
 #
 # When modifying the parameter list, also modify device_manager::devices in devices.pp.
 #
@@ -16,12 +16,6 @@ define device_manager (
   Boolean                $include_module = true,
   Enum[present, absent]  $ensure         = present,
 ) {
-
-  # Validate node.
-
-  unless has_key($facts, 'aio_agent_version') {
-    fail("Classification Error: 'device_manager' declared on a device instead of an agent.")
-  }
 
   # Validate parameters.
 

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -8,23 +8,6 @@ describe 'device_manager' do
     ]
   end
 
-  context 'declared on a device' do
-    let(:title) { 'cisco.example.com' }
-    let(:params) do
-      {
-        ensure: :present,
-        type: 'cisco_ios',
-      }
-    end
-    let(:facts) do
-      {
-        os: { family: 'cisco_ios' },
-      }
-    end
-
-    it { is_expected.to raise_error(%r{declared on a device}) }
-  end
-
   context 'declared on Linux, running Puppet 5.0, with values for all device.conf parameters' do
     let(:title) { 'f5.example.com' }
     let(:params) do


### PR DESCRIPTION
The `aio_agent_version` fact is provided by a Puppet Enterprise module which means open source users will be unable to use the device manager and would result in errors similar to the following:

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, Classification Error: 'device_manager' declared on a device instead of an agent. (file: /etc/puppetlabs/code/environments/production/modules/device_manager/manifests/init.pp, line: 23, column: 5) (file: /etc/puppetlabs/code/environments/production/manifests/site.pp, line: 18)
```