### PR TITLE
(maint) Relax version requirement for concat

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 3.0.0 < 6.0.0"
+      "version_requirement": ">= 3.0.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/hocon",


### PR DESCRIPTION
Since concat only bumped the major version because of dropping puppet
version compatibility, we are compatible to v6, too.