### PR TITLE
(maint) changing the include to use new rsapi manifests

### DIFF
--- a/spec/acceptance/configure_spec.rb
+++ b/spec/acceptance/configure_spec.rb
@@ -6,7 +6,7 @@ describe 'configure' do
   manifest = <<-EOS
 File { backup => false }
 node '#{fqdn}' {
-  include cisco_ios::proxy
+  include cisco_ios
   device_manager {'bigip.example.com':
     type         => 'f5',
     url          => 'https://admin:password@10.0.0.245/',
@@ -29,7 +29,7 @@ EOS
   manifest_with_include_devices = <<-EOS
 File { backup => false }
 node '#{fqdn}' {
-  include cisco_ios::proxy
+  include cisco_ios
   device_manager {'bigip.example.com':
     type         => 'f5',
     url          => 'https://admin:password@10.0.0.245/',


### PR DESCRIPTION
The `include cisco_ios::proxy` and `::server` are deprecated with latest release. Causing duplicate declaration messages for the net-ssh-telnet gem, this change will use the main `cisco_ios` init class and use the course resource_api manifests