### PR TITLE
(MODULES-9191) allow puppet device command to run as --user

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,17 @@ Setting `run_interval` to a value between 1 and 1440 will create a Cron (or on W
 
 [comment]: # (Doing so avoids impractical cron mathematics.)
 
-Note: On versions of Puppet (lower than Puppet 5.x.x) that do not support `puppet device --target`, this parameter will instead create one Cron (or Scheduled Task) resource that executes `puppet device` for all devices in `device.conf` every 60 minutes (at a randomized minute) on the proxy Puppet agent.
+Note: On versions of Puppet (older than 5.0.0) that do not support `puppet device --target`, this parameter will instead create one Cron (or Scheduled Task) resource that executes `puppet device` for all devices in `device.conf` every 60 minutes (at a randomized minute) on the proxy Puppet agent.
+
+### run_user
+
+Data type: String
+
+This parameter is optional.
+
+Specifies the `--user=` parameter when running `puppet device --user=` on the proxy Puppet agent.
+
+Requires Puppet 5.4.0 or newer.
 
 ## Orchestration
 

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Data type: String
 
 This parameter is optional.
 
-Specifies the `--user=` parameter when running `puppet device --user=` on the proxy Puppet agent.
+Specifies the `--user=` parameter for scheduled `puppet device` runs on the proxy Puppet agent.
 
 Requires Puppet 5.4.0 or newer.
 

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -13,12 +13,12 @@ class device_manager::run {
 
   # PUP-1391 Puppet 5.4.0 eliminates the need for '--user=root'.
   if (versioncmp($::puppetversion, '5.4.0') < 0) {
-    $default_user = '--user=root'
+    $optional_user = ' --user=root'
   } else {
-    $default_user = ''
+    $optional_user = ''
   }
 
-  $arguments = "device ${default_user} --waitforcert=0 --verbose --logdest ${logdest}"
+  $arguments = "device --verbose --waitforcert=0 --logdest=${logdest}${optional_user}"
 
   # PUP-7412 Puppet 5.0.0 introduces '--target=<device>'.
   $targetable = (versioncmp($::puppetversion, '5.0.0') >= 0)

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -11,14 +11,14 @@ class device_manager::run {
     $logdest = 'syslog'
   }
 
-  # PUP-1391 Puppet 5.4.0 does not require '--user=root'.
-  if (versioncmp($::puppetversion, '5.4.0') >= 0) {
-    $user = ''
+  # PUP-1391 Puppet 5.4.0 eliminates the need for '--user=root'.
+  if (versioncmp($::puppetversion, '5.4.0') < 0) {
+    $default_user = '--user=root'
   } else {
-    $user = '--user=root'
+    $default_user = ''
   }
 
-  $arguments = "device ${user} --waitforcert=0 --verbose --logdest ${logdest}"
+  $arguments = "device ${default_user} --waitforcert=0 --verbose --logdest ${logdest}"
 
   # PUP-7412 Puppet 5.0.0 introduces '--target=<device>'.
   $targetable = (versioncmp($::puppetversion, '5.0.0') >= 0)

--- a/manifests/run/via_cron/device.pp
+++ b/manifests/run/via_cron/device.pp
@@ -48,12 +48,12 @@ define device_manager::run::via_cron::device (
     if ($run_user == '') {
       $optional_user = ''
     } else {
-      $optional_user = "--user=${run_user}"
+      $optional_user = " --user=${run_user}"
     }
 
     cron { "run puppet device target ${name}":
       ensure  => $cron_ensure,
-      command => "${device_manager::run::command} ${device_manager::run::arguments} --target=${name} ${optional_user}",
+      command => "${device_manager::run::command} ${device_manager::run::arguments} --target=${name}${optional_user}",
       user    => $::identity['user'],
       hour    => $hour,
       minute  => $minute,

--- a/manifests/run/via_cron/device.pp
+++ b/manifests/run/via_cron/device.pp
@@ -4,6 +4,7 @@
 define device_manager::run::via_cron::device (
   String  $ensure,
   Integer $run_interval,
+  String  $run_user,
 ){
 
   include device_manager::run
@@ -44,9 +45,15 @@ define device_manager::run::via_cron::device (
     # The above, via the interval_to_cron_time function:
     # $cron_time = device_manager::interval_to_cron_time($run_interval, fqdn_rand(max(1,min($run_interval, 59)), $name))
 
+    if ($run_user == '') {
+      $optional_user = ''
+    } else {
+      $optional_user = "--user=${run_user}"
+    }
+
     cron { "run puppet device target ${name}":
       ensure  => $cron_ensure,
-      command => "${device_manager::run::command} ${device_manager::run::arguments} --target=${name}",
+      command => "${device_manager::run::command} ${device_manager::run::arguments} --target=${name} ${optional_user}",
       user    => $::identity['user'],
       hour    => $hour,
       minute  => $minute,

--- a/manifests/run/via_exec/device.pp
+++ b/manifests/run/via_exec/device.pp
@@ -3,14 +3,22 @@
 
 # The puppet command is quoted in this Exec to support spaces in the path on Windows.
 
-define device_manager::run::via_exec::device {
+define device_manager::run::via_exec::device (
+  String  $run_user,
+){
 
   include device_manager::run
 
   if $device_manager::run::targetable {
 
+    if ($run_user == '') {
+      $optional_user = ''
+    } else {
+      $optional_user = "--user=${run_user}"
+    }
+
     exec { "run puppet device target ${name}":
-      command => "\"${device_manager::run::command}\" ${device_manager::run::arguments} --target=${name}",
+      command => "\"${device_manager::run::command}\" ${device_manager::run::arguments} --target=${name} ${optional_user}",
       require => Device_manager::Conf::Device[$name],
       tag     => "run_puppet_device_${name}",
     }

--- a/manifests/run/via_exec/device.pp
+++ b/manifests/run/via_exec/device.pp
@@ -14,11 +14,11 @@ define device_manager::run::via_exec::device (
     if ($run_user == '') {
       $optional_user = ''
     } else {
-      $optional_user = "--user=${run_user}"
+      $optional_user = " --user=${run_user}"
     }
 
     exec { "run puppet device target ${name}":
-      command => "\"${device_manager::run::command}\" ${device_manager::run::arguments} --target=${name} ${optional_user}",
+      command => "\"${device_manager::run::command}\" ${device_manager::run::arguments} --target=${name}${optional_user}",
       require => Device_manager::Conf::Device[$name],
       tag     => "run_puppet_device_${name}",
     }

--- a/manifests/run/via_scheduled_task/device.pp
+++ b/manifests/run/via_scheduled_task/device.pp
@@ -24,13 +24,13 @@ define device_manager::run::via_scheduled_task::device (
     if ($run_user == '') {
       $optional_user = ''
     } else {
-      $optional_user = "--user=${run_user}"
+      $optional_user = " --user=${run_user}"
     }
 
     scheduled_task { "run puppet device target ${task_name}":
       ensure    => $scheduled_task_ensure,
       command   => $device_manager::run::command,
-      arguments => "${device_manager::run::arguments} --target=${name} ${optional_user}",
+      arguments => "${device_manager::run::arguments} --target=${name}${optional_user}",
       trigger   => {
         schedule         => 'daily',
         start_time       => $start_time,

--- a/manifests/run/via_scheduled_task/device.pp
+++ b/manifests/run/via_scheduled_task/device.pp
@@ -4,6 +4,7 @@
 define device_manager::run::via_scheduled_task::device (
   String  $ensure,
   Integer $run_interval,
+  String  $run_user,
 ){
 
   include device_manager::run
@@ -20,10 +21,16 @@ define device_manager::run::via_scheduled_task::device (
     $start_time = "00:${$random_minute}"
     $task_name = regsubst($name, '\.', '_', 'G')
 
+    if ($run_user == '') {
+      $optional_user = ''
+    } else {
+      $optional_user = "--user=${run_user}"
+    }
+
     scheduled_task { "run puppet device target ${task_name}":
       ensure    => $scheduled_task_ensure,
       command   => $device_manager::run::command,
-      arguments => "${device_manager::run::arguments} --target=${name}",
+      arguments => "${device_manager::run::arguments} --target=${name} ${optional_user}",
       trigger   => {
         schedule         => 'daily',
         start_time       => $start_time,


### PR DESCRIPTION
Make the '--user=' parameter of `puppet device` configurable.