### PR TITLE
Remove $devices_directory ownership, ref #61

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -17,8 +17,6 @@ class device_manager::conf {
 
   file { $devices_directory:
     ensure       => directory,
-    owner        => $settings::user,
-    group        => $settings::group,
     purge        => true,
     recurse      => true,
     recurselimit => 1,


### PR DESCRIPTION
Ownership is already implied by `File` on the lines above