### PR TITLE
(MODULES-9191) support configurable user

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,14 @@ Setting `run_interval` to a value between 1 and 1440 will create a Cron (or on W
 
 Note: On versions of Puppet (lower than Puppet 5.x.x) that do not support `puppet device --target`, this parameter will instead create one Cron (or Scheduled Task) resource that executes `puppet device` for all devices in `device.conf` every 60 minutes (at a randomized minute) on the proxy Puppet agent.
 
+### run_user
+
+Data type: String
+
+This parameter is optional, with a default of `$::identity['user']`.
+
+Specifies the user to own the configuration files and any cron jobs on the proxy Puppet agent.
+
 ## Orchestration
 
 ### Puppet Tasks

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -4,21 +4,15 @@
 
 class device_manager::conf {
 
-  if ($facts['os']['family'] != 'windows') {
-    File {
-      owner => $::identity['user'],
-      group => $::identity['group'],
-      mode  => '0640',
-    }
-  }
+  # Cannot pass parameters to included classes.
+  $owner = lookup('device_manager::conf::owner', {'default_value' => $::identity['user']})
+  $group = lookup('device_manager::conf::group', {'default_value' => $::identity['group']})
 
   # Use a fact to identify the confdir file on this agent.
   $devices_directory = "${::puppet_settings_confdir}/puppet/devices"
 
   file { $devices_directory:
     ensure       => directory,
-    owner        => $settings::user,
-    group        => $settings::group,
     purge        => true,
     recurse      => true,
     recurselimit => 1,
@@ -32,8 +26,8 @@ class device_manager::conf {
   concat { $device_conf_file:
     backup    => false,
     show_diff => false,
-    owner     => $::identity['user'],
-    group     => $::identity['group'],
+    owner     => $owner,
+    group     => $group,
     mode      => '0640',
   }
 

--- a/manifests/conf/device.pp
+++ b/manifests/conf/device.pp
@@ -27,8 +27,8 @@ define device_manager::conf::device (
 
       file { $credentials_file:
         ensure  => file,
-        owner   => $::identity['user'],
-        group   => $::identity['group'],
+        owner   => $device_manager::conf::owner,
+        group   => $device_manager::conf::group,
         mode    => '0640',
         content => $credentials_json,
       }

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -3,6 +3,11 @@
 
 class device_manager::run {
 
+  include device_manager::conf
+
+  $owner = $device_manager::conf::owner
+  $group = $device_manager::conf::group
+
   if ($facts['os']['family'] == 'windows') {
     $command = "${::env_windows_installdir}\\bin\\puppet"
     $logdest = 'eventlog'
@@ -24,4 +29,5 @@ class device_manager::run {
   $targetable = (versioncmp($::puppetversion, '5.0.0') >= 0)
 
   $random_minute = sprintf('%02d', fqdn_rand(59, 'device_manager'))
+
 }

--- a/manifests/run/via_cron/device.pp
+++ b/manifests/run/via_cron/device.pp
@@ -47,7 +47,7 @@ define device_manager::run::via_cron::device (
     cron { "run puppet device target ${name}":
       ensure  => $cron_ensure,
       command => "${device_manager::run::command} ${device_manager::run::arguments} --target=${name}",
-      user    => $::identity['user'],
+      user    => $device_manager::run::owner,
       hour    => $hour,
       minute  => $minute,
       # hour     => $cron_time['hour'],

--- a/manifests/run/via_cron/untargeted.pp
+++ b/manifests/run/via_cron/untargeted.pp
@@ -5,14 +5,12 @@
 
 class device_manager::run::via_cron::untargeted {
 
-  $minute = $device_manager::run::random_minute
-
   cron { 'run puppet device':
     ensure  => present,
     command => "${device_manager::run::command} ${device_manager::run::arguments}",
-    user    => $::identity['user'],
+    user    => $device_manager::run::owner,
     hour    => '*',
-    minute  => $minute,
+    minute  => $device_manager::run::random_minute,
   }
 
 }

--- a/manifests/run/via_scheduled_task/untargeted.pp
+++ b/manifests/run/via_scheduled_task/untargeted.pp
@@ -5,15 +5,13 @@
 
 class device_manager::run::via_scheduled_task::untargeted {
 
-  $start_time = "00:${device_manager::run::random_minute}"
-
   scheduled_task { 'run puppet device':
     ensure    => present,
     command   => $device_manager::run::command,
     arguments => $device_manager::run::arguments,
     trigger   => {
       schedule         => 'daily',
-      start_time       => $start_time,
+      start_time       => "00:${device_manager::run::random_minute}",
       minutes_interval => '60',
     }
   }

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -198,30 +198,6 @@ describe 'device_manager' do
     }
   end
 
-  context 'declared on Linux, running Puppet 5.0, with run_interval and run_via_exec parameters' do
-    let(:title) { 'f5.example.com' }
-    let(:params) do
-      {
-        ensure: :present,
-        type: 'f5',
-        url: 'https://admin:password@10.0.0.245/',
-        run_interval: 30,
-        run_via_exec: true,
-      }
-    end
-    let(:facts) do
-      {
-        aio_agent_version: '5.0.0',
-        puppetversion: '5.0.0',
-        puppet_settings_deviceconfig: '/etc/puppetlabs/puppet/device.conf',
-        puppet_settings_confdir: '/etc/puppetlabs',
-        os: { family: 'redhat' },
-      }
-    end
-
-    it { is_expected.to raise_error(%r{are mutually-exclusive}) }
-  end
-
   context 'declared on Linux, running Puppet 5.5, with credentials' do
     let(:title) { 'cisco.example.com' }
     let(:params) do
@@ -252,28 +228,5 @@ describe 'device_manager' do
     # it {
     #   is_expected.to contain_concat_fragment("device_manager_conf [#{title}]").with('content').including("url file://#{device_credentials_file}")
     # }
-  end
-
-  context 'declared on Linux, running Puppet 5.5, with credentials and url parameters' do
-    let(:title) { 'cisco.example.com' }
-    let(:params) do
-      {
-        ensure: :present,
-        type: 'cisco_ios',
-        credentials: { 'address' => '10.0.0.245', 'port' => 22, 'username' => 'admin', 'password' => 'cisco', 'enable_password' => 'cisco' },
-        url: 'https://admin:cisco@10.0.0.245/',
-      }
-    end
-    let(:facts) do
-      {
-        aio_agent_version: '5.5.0',
-        puppetversion: '5.5.0',
-        puppet_settings_deviceconfig: '/etc/puppetlabs/puppet/device.conf',
-        puppet_settings_confdir: '/etc/puppetlabs',
-        os: { family: 'redhat' },
-      }
-    end
-
-    it { is_expected.to raise_error(%r{are mutually-exclusive}) }
   end
 end


### PR DESCRIPTION
Allow specification of a user and group for configuration files,
add use that user for any potential 'puppet device' cron jobs.

Since the user and group are used for a common parent folder,
this is not a per-device setting set via Hiera.