### PR TITLE
(MODULES-9191) implement configurable run_user per device

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,24 @@ Setting `run_interval` to a value between 1 and 1440 will create a Cron (or on W
 
 Note: On versions of Puppet (lower than Puppet 5.x.x) that do not support `puppet device --target`, this parameter will instead create one Cron (or Scheduled Task) resource that executes `puppet device` for all devices in `device.conf` every 60 minutes (at a randomized minute) on the proxy Puppet agent.
 
+###  run_user
+
+Data type: String
+
+This parameter is optional, with a default of `$::identity['user']`.
+
+Specifies the user to own the configuration files and any cron job or scheduled task for the device on the proxy Puppet agent.
+
+Note: On versions of Puppet (lower than Puppet 5.x.x) that do not support `puppet device --target`, this parameter will not set the `user` of the one Cron (or Scheduled Task) resource.
+
+###  run_group
+
+Data type: String
+
+This parameter is optional, with a default of `$::identity['group']`.
+
+Specifies the group to own the configuration files for the device on the proxy Puppet agent.
+
 ## Orchestration
 
 ### Puppet Tasks

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -4,21 +4,11 @@
 
 class device_manager::conf {
 
-  if ($facts['os']['family'] != 'windows') {
-    File {
-      owner => $::identity['user'],
-      group => $::identity['group'],
-      mode  => '0640',
-    }
-  }
-
   # Use a fact to identify the confdir file on this agent.
   $devices_directory = "${::puppet_settings_confdir}/puppet/devices"
 
   file { $devices_directory:
     ensure       => directory,
-    owner        => $settings::user,
-    group        => $settings::group,
     purge        => true,
     recurse      => true,
     recurselimit => 1,
@@ -32,8 +22,6 @@ class device_manager::conf {
   concat { $device_conf_file:
     backup    => false,
     show_diff => false,
-    owner     => $::identity['user'],
-    group     => $::identity['group'],
     mode      => '0640',
   }
 

--- a/manifests/conf/device.pp
+++ b/manifests/conf/device.pp
@@ -6,6 +6,8 @@ define device_manager::conf::device (
   String                    $type,
   String                    $url,
   Hash                      $credentials,
+  String                    $run_user,
+  String                    $run_group,
   Boolean                   $debug = false,
   Enum[present, absent]     $ensure = present,
 ) {
@@ -27,8 +29,8 @@ define device_manager::conf::device (
 
       file { $credentials_file:
         ensure  => file,
-        owner   => $::identity['user'],
-        group   => $::identity['group'],
+        owner   => $run_user,
+        group   => $run_group,
         mode    => '0640',
         content => $credentials_json,
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,8 @@ define device_manager (
   Boolean                $debug          = false,
   Integer[0,1440]        $run_interval   = 0,
   Boolean                $run_via_exec   = false,
+  String                 $run_user       = $::identity['user'],
+  String                 $run_group      = $::identity['group'],
   Boolean                $include_module = true,
   Enum[present, absent]  $ensure         = present,
 ) {
@@ -38,6 +40,8 @@ define device_manager (
     type        => $type,
     url         => $url,
     credentials => $credentials,
+    run_user    => $run_user,
+    run_group   => $run_group,
     debug       => $debug,
   }
 
@@ -53,11 +57,13 @@ define device_manager (
     device_manager::run::via_scheduled_task::device { $name:
       ensure       => $ensure,
       run_interval => $run_interval,
+      run_user     => $run_user,
     }
   } else {
     device_manager::run::via_cron::device { $name:
       ensure       => $ensure,
       run_interval => $run_interval,
+      run_user     => $run_user,
     }
   }
 

--- a/manifests/run/via_cron/device.pp
+++ b/manifests/run/via_cron/device.pp
@@ -4,6 +4,7 @@
 define device_manager::run::via_cron::device (
   String  $ensure,
   Integer $run_interval,
+  String  $run_user,
 ){
 
   include device_manager::run
@@ -47,7 +48,7 @@ define device_manager::run::via_cron::device (
     cron { "run puppet device target ${name}":
       ensure  => $cron_ensure,
       command => "${device_manager::run::command} ${device_manager::run::arguments} --target=${name}",
-      user    => $::identity['user'],
+      user    => $run_user,
       hour    => $hour,
       minute  => $minute,
       # hour     => $cron_time['hour'],

--- a/manifests/run/via_cron/untargeted.pp
+++ b/manifests/run/via_cron/untargeted.pp
@@ -5,14 +5,11 @@
 
 class device_manager::run::via_cron::untargeted {
 
-  $minute = $device_manager::run::random_minute
-
   cron { 'run puppet device':
     ensure  => present,
     command => "${device_manager::run::command} ${device_manager::run::arguments}",
-    user    => $::identity['user'],
     hour    => '*',
-    minute  => $minute,
+    minute  => $device_manager::run::random_minute,
   }
 
 }

--- a/manifests/run/via_scheduled_task/device.pp
+++ b/manifests/run/via_scheduled_task/device.pp
@@ -4,6 +4,7 @@
 define device_manager::run::via_scheduled_task::device (
   String  $ensure,
   Integer $run_interval,
+  String  $run_user,
 ){
 
   include device_manager::run
@@ -28,7 +29,8 @@ define device_manager::run::via_scheduled_task::device (
         schedule         => 'daily',
         start_time       => $start_time,
         minutes_interval => $run_interval,
-      }
+      },
+      user      => $run_user,
     }
 
   } else {

--- a/manifests/run/via_scheduled_task/untargeted.pp
+++ b/manifests/run/via_scheduled_task/untargeted.pp
@@ -5,15 +5,13 @@
 
 class device_manager::run::via_scheduled_task::untargeted {
 
-  $start_time = "00:${device_manager::run::random_minute}"
-
   scheduled_task { 'run puppet device':
     ensure    => present,
     command   => $device_manager::run::command,
     arguments => $device_manager::run::arguments,
     trigger   => {
       schedule         => 'daily',
-      start_time       => $start_time,
+      start_time       => "00:${device_manager::run::random_minute}",
       minutes_interval => '60',
     }
   }

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -198,30 +198,6 @@ describe 'device_manager' do
     }
   end
 
-  context 'declared on Linux, running Puppet 5.0, with run_interval and run_via_exec parameters' do
-    let(:title) { 'f5.example.com' }
-    let(:params) do
-      {
-        ensure: :present,
-        type: 'f5',
-        url: 'https://admin:password@10.0.0.245/',
-        run_interval: 30,
-        run_via_exec: true,
-      }
-    end
-    let(:facts) do
-      {
-        aio_agent_version: '5.0.0',
-        puppetversion: '5.0.0',
-        puppet_settings_deviceconfig: '/etc/puppetlabs/puppet/device.conf',
-        puppet_settings_confdir: '/etc/puppetlabs',
-        os: { family: 'redhat' },
-      }
-    end
-
-    it { is_expected.to raise_error(%r{are mutually-exclusive}) }
-  end
-
   context 'declared on Linux, running Puppet 5.5, with credentials' do
     let(:title) { 'cisco.example.com' }
     let(:params) do
@@ -252,28 +228,5 @@ describe 'device_manager' do
     # it {
     #   is_expected.to contain_concat_fragment("device_manager_conf [#{title}]").with('content').including("url file://#{device_credentials_file}")
     # }
-  end
-
-  context 'declared on Linux, running Puppet 5.5, with credentials and url parameters' do
-    let(:title) { 'cisco.example.com' }
-    let(:params) do
-      {
-        ensure: :present,
-        type: 'cisco_ios',
-        credentials: { 'address' => '10.0.0.245', 'port' => 22, 'username' => 'admin', 'password' => 'cisco', 'enable_password' => 'cisco' },
-        url: 'https://admin:cisco@10.0.0.245/',
-      }
-    end
-    let(:facts) do
-      {
-        aio_agent_version: '5.5.0',
-        puppetversion: '5.5.0',
-        puppet_settings_deviceconfig: '/etc/puppetlabs/puppet/device.conf',
-        puppet_settings_confdir: '/etc/puppetlabs',
-        os: { family: 'redhat' },
-      }
-    end
-
-    it { is_expected.to raise_error(%r{are mutually-exclusive}) }
   end
 end


### PR DESCRIPTION
Allow specification of a user and group for configuration files,
add use that user for any cron or scheduled tasks.

This per-resource parameter cannot be applied to any common
"untargeted" resources that allow pre-Puppet 5.x.x support.

This commit also drops spec tests for simple if statements.