### PR TITLE
Do not require aio_agent_version to be present

### DIFF
--- a/manifests/devices.pp
+++ b/manifests/devices.pp
@@ -14,12 +14,6 @@ class device_manager::devices (
   Hash $defaults = {},
 ) {
 
-  # Validate node.
-
-  unless has_key($facts, 'aio_agent_version') {
-    fail("Classification Error: 'device_manager::devices' declared on a device instead of an agent.")
-  }
-
   # Initialize the concat resources used by conf and fact.
   # This allows an empty device_manager::devices hash to clear undeclared devices from conf and facts.
   # Note that concat is not used by run, resulting in orphaned Cron (or Scheduled Task) resources.


### PR DESCRIPTION
This was started in PR #41 but one more check was left behind in device_manager::devices

I don't even think it's an enterprise/non-enterprise distinction. It looks like packaging differences:
When facter is built as part of the puppet-agent package, as it does in the puppetlabs yum repo, it gets the agent version fact compiled in from the config variable. Hence, I suspect, the aio (all-in-one) prefix.
If facter lives in a separate package, as it does in Arch official repos, it can't have the fact compiled in, as the agent version can change independently. At least this is the way I understand it.

As an Arch user, this is the second puppet module where I run into problems with missing aio_agent_version.