### PR TITLE
Manage device config folder

### DIFF
--- a/manifests/conf/device.pp
+++ b/manifests/conf/device.pp
@@ -46,6 +46,13 @@ define device_manager::conf::device (
       tag     => "device_${name}",
     }
 
+    file { "${::puppet_settings_confdir}/puppet/devices/${name}":
+      ensure => directory,
+      owner  => $run_user,
+      group  => $run_group,
+      mode   => '0755',
+    }
+
   } else {
 
     file { $credentials_file:


### PR DESCRIPTION
This folder usually gets created by the puppet device itself, but since purging of the devices folder is enabled, the puppet agent tries to delete this folder