### PR TITLE
(maint) confine and variables and ensure

### DIFF
--- a/lib/facter/puppet_device_paths.rb
+++ b/lib/facter/puppet_device_paths.rb
@@ -11,7 +11,9 @@ Facter.add('puppet_settings_confdir') do
 end
 
 Facter.add('puppet_settings_confdir') do
-  confine osfamily: :windows
+  confine :os do |os|
+    os['family'] == 'windows'
+  end
   setcode do
     File.dirname(File.dirname(Puppet.settings['confdir']))
   end

--- a/manifests/conf/device.pp
+++ b/manifests/conf/device.pp
@@ -15,6 +15,7 @@ define device_manager::conf::device (
   include device_manager::conf
 
   $credentials_file = "${device_manager::conf::devices_directory}/${name}.conf"
+  $device_directory = "${device_manager::conf::devices_directory}/${name}"
 
   if ($ensure == present) {
 
@@ -46,7 +47,7 @@ define device_manager::conf::device (
       tag     => "device_${name}",
     }
 
-    file { "${::puppet_settings_confdir}/puppet/devices/${name}":
+    file { $device_directory:
       ensure => directory,
       owner  => $run_user,
       group  => $run_group,
@@ -60,6 +61,10 @@ define device_manager::conf::device (
     }
 
     # Do not define a concat::fragment for this device, ensuring 'absent'.
+
+    file { $device_directory:
+      ensure => absent,
+    }
 
   }
 


### PR DESCRIPTION
Prepare for the sunset of legacy facts.
Use the existing $devices_directory variable.
Ensure $devices_directory is absent when ensure resource is absent.