### PR TITLE
run_user and run_group for device_manager::devices

### DIFF
--- a/manifests/devices.pp
+++ b/manifests/devices.pp
@@ -75,6 +75,8 @@ class device_manager::devices (
       run_interval   => $params['run_interval'],
       run_via_exec   => $params['run_via_exec'],
       include_module => $params['include_module'],
+      run_user       => $params['run_user'],
+      run_group      => $params['run_group'],
     }
   }
 }


### PR DESCRIPTION
Allows users to customize run_user and run_group on device_manager to fix #65 