### PR TITLE
Update for Puppet 7 compability

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-device_manager",
-  "version": "3.2.0",
+  "version": "3.1.0",
   "author": "puppetlabs",
   "summary": "Manage devices used by 'puppet device' on puppet agents.",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -76,7 +76,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 8.0.0"
+      "version_requirement": ">= 5.5.10 < 8.0.0"
     }
   ],
   "tags": [

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-device_manager",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "author": "puppetlabs",
   "summary": "Manage devices used by 'puppet device' on puppet agents.",
   "license": "Apache-2.0",
@@ -18,49 +18,65 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.10.0 < 8.0.0"
+      "version_requirement": ">= 4.13.1 < 9.0.0"
     }
   ],
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "5",
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "12.04",
         "14.04",
-        "16.04"
+        "16.04",
+        "18.04",
+        "20.04"
       ]
     },
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
-        "Server 2008",
-        "Server 2008 R2",
-        "Server 2012",
-        "Server 2012 R2",
-        "Server 2016"
+        "2008 R2",
+        "2012",
+        "2012 R2",
+        "2016",
+        "2012 R2 Core",
+        "7",
+        "8.1",
+        "10"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.10 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
Puppet 7 removes lib/puppet/ssl/host.rb and the Puppet::SSL::Host class.
The `Puppet.valid_digest_algorithms` method works just fine.
This addresses Issue #85 